### PR TITLE
Fix reverse not defined error

### DIFF
--- a/gitreaper.py
+++ b/gitreaper.py
@@ -86,7 +86,7 @@ class GitReaper(object):
         with open(os.path.abspath(configfile)) as file:
             return yaml.load(file, Loader=yaml.FullLoader)
 
-    def _repo_sync(self, project, ymlconfig):
+    def _repo_sync(self, project, ymlconfig, reverse):
         upstream_repo = ymlconfig[project]["upstream"]
         downstream_repo = ymlconfig[project]["url"]
         flags = ymlconfig[project].get("flags") or ""
@@ -145,9 +145,9 @@ class GitReaper(object):
         ymlconfig = self.parseConfigFile(configfile)
         if project is None:
             for project_entry in ymlconfig:
-                self._repo_sync(project_entry, ymlconfig)
+                self._repo_sync(project_entry, ymlconfig, reverse)
         else:
-            self._repo_sync(project, ymlconfig)
+            self._repo_sync(project, ymlconfig, reverse)
 
     def sendPatchUpstream(self, configfile, project):
         return


### PR DESCRIPTION
Broken by 8f845a5a76

Fixes the below error:
File "/srv/projects/git-reaper/./gitreaper.py", line 97, in _repo_sync
    if reverse:
NameError: name 'reverse' is not defined. Did you mean: 'reversed'?

Signed-off-by: Vijai Kumar K <vijaikumar.kanagarajan@gmail.com>