### PR TITLE
Continue sync of other projects if NO is specified

### DIFF
--- a/gitreaper.py
+++ b/gitreaper.py
@@ -129,9 +129,11 @@ class GitReaper(object):
             question = "{} {}".format(question, " YES/NO: ")
             try:
                 if not confirm_user(question):
-                    sys.exit("sync aborted")
+                    print("sync aborted")
+                    return
             except KeyboardInterrupt:
-                sys.exit("\nsync aborted")
+                print("\nsync aborted")
+                return
             sync_specific_branches(
                 project,
                 upstream_repo,


### PR DESCRIPTION
With the current implemetation, specifying NO aborts program. Make the logic skip the entry and proceed with others.

Signed-off-by: Vijai Kumar K <vijaikumar.kanagarajan@gmail.com>